### PR TITLE
fix: replace deprecated requestWithAuthentication method

### DIFF
--- a/nodes/Docutray/Docutray.node.ts
+++ b/nodes/Docutray/Docutray.node.ts
@@ -57,7 +57,7 @@ export class Docutray implements INodeType {
 						json: true,
 					};
 
-					const response = await this.helpers.requestWithAuthentication.call(
+					const response = await this.helpers.httpRequestWithAuthentication.call(
 						this,
 						'docutrayApi',
 						requestOptions,
@@ -121,7 +121,7 @@ export class Docutray implements INodeType {
 							json: true,
 						};
 
-						const responseData = await this.helpers.requestWithAuthentication.call(
+						const responseData = await this.helpers.httpRequestWithAuthentication.call(
 							this,
 							'docutrayApi',
 							requestOptions,
@@ -245,7 +245,7 @@ export class Docutray implements INodeType {
 						requestOptions.json = true;
 					}
 
-					const responseData = await this.helpers.requestWithAuthentication.call(
+					const responseData = await this.helpers.httpRequestWithAuthentication.call(
 						this,
 						'docutrayApi',
 						requestOptions,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-docutray",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-docutray",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-docutray",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "n8n community nodes for Docutray OCR, document identification, and knowledge base search services",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
## Summary
- Replaced all instances of deprecated `requestWithAuthentication` with `httpRequestWithAuthentication` to comply with n8n community node guidelines
- Updated package version to 0.4.2

## Changes
This PR addresses the deprecation warnings found by the n8n package scanner by replacing the deprecated helper method in three locations:
- Knowledge base list loading (line 60)
- Knowledge base search operation (line 124)  
- Document convert/identify operations (line 248)

## Test plan
- [x] Build completes successfully
- [x] Local verification shows correct method usage in compiled output
- [ ] Package scanner verification (requires npm publication)

## Related
Fixes scanner error: `'requestWithAuthentication' is deprecated. Use 'httpRequestWithAuthentication' instead for better authentication support and consistency`

🤖 Generated with [Claude Code](https://claude.com/claude-code)