### PR TITLE
Refactor binary uploads to use JSON/base64 format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.4] - 2025-10-10
+
+### Changed
+- Refactor binary data uploads to use JSON/base64 format instead of multipart/form-data
+- Eliminate external `form-data` library dependency (passes n8n Cloud verification)
+- Unify all input methods (binaryData, base64, url) to use consistent JSON format
+- Simplify codebase: 380 lines → 263 lines (-117 lines)
+
 ## [0.4.3] - 2025-10-10
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,23 @@ Uses `eslint-plugin-n8n-nodes-base` with community package rules. Configured to 
 ## Testing Locally
 Install n8n globally (`npm install n8n -g`) and link this package for local testing with n8n's development environment.
 
+## Development Workflow
+
+### Branch Strategy
+- **Main branch**: `master`
+- **Development**: Always create feature branches from `master`
+- **Integration**: All changes must be merged to `master` via Pull Request
+- **Never commit directly to master**: Use PRs for code review and validation
+
+### Pull Request Process
+1. Create feature branch from `master`: `git checkout -b feature/description`
+2. Make changes and commit with descriptive messages
+3. Push branch: `git push origin feature/description`
+4. Create Pull Request to `master`
+5. Ensure all validations pass (build, lint, format, scanner)
+6. Merge PR (squash recommended for cleaner history)
+7. Delete feature branch after merge
+
 ## Verification and Publication
 
 ### Pre-Publication Verification

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-docutray",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-docutray",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-docutray",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "n8n community nodes for Docutray OCR, document identification, and knowledge base search services",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
## Summary

Refactors binary data uploads to eliminate the `form-data` library dependency by using JSON/base64 format for all input methods. This change ensures the package passes n8n Cloud verification requirements.

## Problem

Version 0.4.3 failed n8n Cloud verification with:
```
❌ ESLint violations found
Require of 'form-data' is not allowed. n8n Cloud does not allow community nodes with dependencies
```

The previous implementation used the `form-data` library to work around n8n issue #18271, but this external dependency violates n8n Cloud's strict no-dependency policy.

## Solution

Recognized that binary data in n8n is already stored as base64 (`binaryData.data`), so we can:
1. Extract base64 data directly from `binaryData.data`
2. Send via JSON format with `image_base64` and `image_content_type` fields
3. Use the same approach for all input methods (binaryData, base64, url)
4. Leverage Docutray API's native support for JSON/base64 format

## Changes

- **Unified input handling**: All three input methods (binaryData, base64, url) now use consistent JSON format
- **Removed external dependency**: Eliminated `form-data` library completely
- **Simplified authentication**: All requests use `httpRequestWithAuthentication` helper
- **Code reduction**: 380 lines → 263 lines (-117 lines, -30%)
- **Updated documentation**: CHANGELOG.md and CLAUDE.md with development workflow

## Testing

- ✅ Local build passed: `npm run build`
- ✅ ESLint validation passed: `npm run lint`
- ✅ Pre-publish checks passed: `npm run prepublishOnly`
- ✅ Format validation passed: `npm run format`
- 🔄 Pending: Remote validation after merge and npm publish

## Technical Details

Binary data in n8n:
```typescript
// binaryData.data is already base64-encoded string in n8n
const binaryData = this.helpers.assertBinaryData(i, binaryPropertyName);

// No conversion needed - just pass through
requestBody.image_base64 = binaryData.data;
requestBody.image_content_type = binaryData.mimeType;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)