### PR TITLE
feat: add dynamic document type selector

### DIFF
--- a/nodes/Docutray/DocumentDescription.ts
+++ b/nodes/Docutray/DocumentDescription.ts
@@ -114,9 +114,12 @@ const convertOperation: INodeProperties[] = [
 		description: 'URL of the image to process',
 	},
 	{
-		displayName: 'Document Type Code',
+		displayName: 'Document Type Code Name or ID',
 		name: 'documentTypeCode',
-		type: 'string',
+		type: 'options',
+		typeOptions: {
+			loadOptionsMethod: 'getDocumentTypes',
+		},
 		required: true,
 		displayOptions: {
 			show: {
@@ -125,7 +128,9 @@ const convertOperation: INodeProperties[] = [
 			},
 		},
 		default: '',
-		description: 'Document type code to specify the expected document format',
+		description: 'Choose from the list or enter a code manually. Choose from the list, or specify a code using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+		hint: 'Select a document type from the dropdown or enter its code directly',
+		placeholder: 'Select document type or enter code',
 	},
 	{
 		displayName: 'Image Content Type',
@@ -255,9 +260,12 @@ const identifyOperation: INodeProperties[] = [
 		description: 'URL of the image to process',
 	},
 	{
-		displayName: 'Document Type Options',
-		name: 'documentTypeOptions',
-		type: 'fixedCollection',
+		displayName: 'Document Type Codes',
+		name: 'documentTypeCodes',
+		type: 'multiOptions',
+		typeOptions: {
+			loadOptionsMethod: 'getDocumentTypes',
+		},
 		required: true,
 		displayOptions: {
 			show: {
@@ -265,28 +273,10 @@ const identifyOperation: INodeProperties[] = [
 				operation: ['identify'],
 			},
 		},
-		default: { values: [] },
-		description: 'List of possible document type codes',
-		options: [
-			{
-				name: 'values',
-				displayName: 'Document Types',
-				values: [
-					{
-						displayName: 'Document Type Code',
-						name: 'code',
-						type: 'string',
-						default: '',
-						required: true,
-						description: 'Document type code (e.g., cartola_cc, cartola_tc)',
-						placeholder: 'cartola_cc',
-					},
-				],
-			},
-		],
-		typeOptions: {
-			multipleValues: true,
-		},
+		default: [],
+		description: 'Choose from the list or enter codes manually. Choose from the list, or specify codes using an <a href="https://docs.n8n.io/code/expressions/">expression</a>. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+		hint: 'Select one or more document types from the dropdown or enter codes directly',
+		placeholder: 'Select document types or enter codes',
 	},
 	{
 		displayName: 'Image Content Type',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-docutray",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "description": "n8n community nodes for Docutray OCR, document identification, and knowledge base search services",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
## Summary

This PR adds dynamic document type selection for both Convert and Identify operations, replacing manual text input with API-powered dropdowns that fetch available document types from the Docutray API.

### Changes

- **New LoadOptions Method**: Added `getDocumentTypes()` to fetch document types from `/api/document-types`
- **Convert Operation**: Changed `documentTypeCode` from text input to single-select dropdown
- **Identify Operation**: Replaced `fixedCollection` with `multiOptions` for multiple document type selection
- **Simplified Logic**: Refactored execute method to handle the new multiOptions format more cleanly
- **Version Bump**: Updated from 0.4.4 → 0.5.0 (minor version for new feature)

### Technical Details

- Document types are fetched without filters (shows all types: public, private, draft, published)
- Dropdown displays only the document type name (not description) for cleaner UX
- The `codeType` field is used as the value sent to the API
- Maintains backward compatibility with manual code entry
- Follows the same pattern as the existing Knowledge Base selector

### Testing

- ✅ Build: Compilation successful
- ✅ Lint: No violations (auto-fixed by ESLint)
- ⚠️ Scanner: Will pass after publication (currently scans old npm version 0.4.3)

### API Integration

The implementation uses the existing `/api/document-types` endpoint with:
- Authentication: Bearer token (same as other endpoints)
- Parameters: `limit=100` (no additional filters)
- Response format: `{ data: [...], pagination: {...} }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)