### PR TITLE
fix: update Convert operation action label to reflect JSON output (v0.5.1)

### DIFF
--- a/nodes/Docutray/DocumentDescription.ts
+++ b/nodes/Docutray/DocumentDescription.ts
@@ -16,7 +16,7 @@ export const documentOperations: INodeProperties[] = [
 				name: 'Convert',
 				value: 'convert',
 				description: 'Extract text from document using OCR',
-				action: 'Convert document to text',
+				action: 'Convert document to JSON',
 				routing: {
 					request: {
 						method: 'POST',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-docutray",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-docutray",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-docutray",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "n8n community nodes for Docutray OCR, document identification, and knowledge base search services",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
## Summary
- Updated the Convert operation action label from "Convert document to text" to "Convert document to JSON" to accurately reflect that the operation returns structured JSON data
- Bumped package version to 0.5.1

## Changes
- Modified `nodes/Docutray/DocumentDescription.ts`: Changed action label for Convert operation
- Updated `package.json` and `package-lock.json` with new version 0.5.1

## Test plan
- [x] Build the package successfully (`npm run build`)
- [x] Verify the action label displays correctly in n8n UI
- [x] Test Convert operation returns JSON output as expected
- [x] Run linting checks (`npm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)