### PR TITLE
fix: remove unnecessary @types/node from devDependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] - 2025-10-20
+
+### Changed
+- Remove unnecessary @types/node from devDependencies (types provided by n8n-workflow peer dependency)
+
+## [0.5.1] - 2025-10-13
+
+### Changed
+- Update Convert operation action label from "Convert document to text" to "Convert document to JSON" for accuracy
+
 ## [0.5.0] - 2025-10-10
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,14 @@
 {
   "name": "n8n-nodes-docutray",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-docutray",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "MIT",
       "devDependencies": {
-        "@types/node": "^24.5.2",
         "@typescript-eslint/parser": "~8.32.0",
         "eslint": "^8.57.0",
         "eslint-plugin-n8n-nodes-base": "^1.16.3",
@@ -333,16 +332,6 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/node": {
-      "version": "24.5.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
-      "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~7.12.0"
-      }
     },
     "node_modules/@types/semver": {
       "version": "7.7.1",
@@ -4630,13 +4619,6 @@
       "dependencies": {
         "fastest-levenshtein": "^1.0.7"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
-      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/upper-case-first": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-docutray",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "n8n community nodes for Docutray OCR, document identification, and knowledge base search services",
   "keywords": [
     "n8n-community-node-package",
@@ -47,7 +47,6 @@
     ]
   },
   "devDependencies": {
-    "@types/node": "^24.5.2",
     "@typescript-eslint/parser": "~8.32.0",
     "eslint": "^8.57.0",
     "eslint-plugin-n8n-nodes-base": "^1.16.3",


### PR DESCRIPTION
## Summary
- Removed `@types/node` from devDependencies (types provided by n8n-workflow peer dependency)
- Bumped version from 0.5.1 to 0.5.2
- Added missing 0.5.1 changelog entry
- Addresses [MEDIUM] severity issue from n8n package scanner

## Changes
- **package.json**: Removed `@types/node` dependency, bumped version to 0.5.2
- **package-lock.json**: Updated to reflect dependency removal and version bump
- **CHANGELOG.md**: Added entries for both 0.5.1 and 0.5.2

## Validation
✅ TypeScript compilation successful
✅ ESLint passes without errors
✅ n8n package scanner validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)